### PR TITLE
adding a check to see if plex is already installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.retry
+.idea/
+ansible-role-plex.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - ansible-playbook -v --diff tests/test.yml
   - >
     ansible-playbook tests/test.yml
-    | grep -q 'changed=0.*failed=0'
+    | grep -q 'changed=1.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
   - 'curl -X GET http://localhost:32400'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Version
-plex_server_version: '1.1.4.2757-24ffd60'
+plex_server_version: '1.5.7.4016-25d94bad9'
 
 # Application config
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,27 @@
 ---
+- name: "Checking installed/running version"
+  shell: ps -ef | grep -i plex | grep {{ plex_server_version }} &> /dev/null
+  register: process_results
+
 - name: "Download the .deb file for Plex Media Server version {{ plex_server_version }}"
   get_url:
     url: "https://downloads.plex.tv/plex-media-server/{{ plex_server_version }}/plexmediaserver_{{ plex_server_version }}_amd64.deb"
     dest: "/tmp/plexmediaserver_{{ plex_server_version }}_amd64.deb"
     mode: '0644'
+  when: process_results.stdout == ""
 
 - name: "Install Plex Media Server version {{ plex_server_version }}"
   apt:
     deb: "/tmp/plexmediaserver_{{ plex_server_version }}_amd64.deb"
     state: 'installed'
   notify: 'restart-ansible-role-plex'
+  when: process_results.stdout == ""
 
 - name: 'Start the plexmediaserver daemon'
   service:
     name: 'plexmediaserver'
     state: 'started'
     enabled: 'yes'
+  when: process_results.stdout == ""
 
 - meta: flush_handlers


### PR DESCRIPTION
i often re-run my roles and found this one taking a bit of time (on my slow internet connection), so I added a check to see if plex is running the same version as specified in the config, if so it skips download, install and restart.
tests were updated as well to match the required change 
- now one task will be "changed" always when reviewing version
- updated plex version in default variables as the older version now 404s and breaks the tests